### PR TITLE
TiffViewer supports double-quoted path input

### DIFF
--- a/Scripts/TiffViewer.m
+++ b/Scripts/TiffViewer.m
@@ -54,7 +54,10 @@ classdef TiffViewer < handle
                     n_ch=str2double(userinputs{1});
                 end
             end
-            if ischar(filename)
+            if ischar(filename) || isstring(filename) 
+                if isstring(filename)
+                    filename = char(filename);
+                end
                 [folder,file,ext]=fileparts(filename);
                 if ~isempty(ext)
                     obj.filename=filename;


### PR DESCRIPTION
Thank you so much for your code
However, I found that TiffViewer does not support double quoted path input, so I  made a improvement
```matlab
a = TiffViewer("E:\Desktop\reg.tif");
```